### PR TITLE
test removing repo name

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+name: Welcome to Oracle Linux Training Station
+title: null


### PR DESCRIPTION
Providing the given _config.yml file removes the extra rendered repo name at the top of the page.