### PR TITLE
home and what's new page updates - Correcting product names

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
             <ul>
                <li><a href="https://oracle-samples.github.io/oltrain/OCNE/ocne.html#ocne-kubernetes">Kubernetes</a></li>
                <li><a href="https://oracle-samples.github.io/oltrain/OL/virt/virt.html#containers">Containers</a></li>
-	       <li><a href="https://oracle-samples.github.io/oltrain/OSMH/osmh.html">OS Management Hub</a></li>
+	       <li><a href="https://oracle-samples.github.io/oltrain/OSMH/osmh.html">Oracle OS Management Hub</a></li>
                <li><a href="https://oracle-samples.github.io/oltrain/VBOX/vbox.html">Oracle VM VirtualBox</a></li>
                <li><a href="https://oracle-samples.github.io/oltrain/OLVM/olvm.html">Oracle Linux Virtualization Manager</a></li>
             </ul>
@@ -61,13 +61,13 @@
    
 <p><a href="https://oracle-samples.github.io/oltrain/OSMH/osmh.html"><img id="osms" src="common/images/osmh-banner-v2.png"></a></p>   
    
-- [OS Management Hub](./OSMH/osmh.md) - Learn how to use OS Management Hub to manage and monitor updates and patches for the operating system environments in private data centers.
+- [Oracle OS Management Hub](./OSMH/osmh.md) - Learn how to use Oracle OS Management Hub to manage and monitor updates and patches for the operating system environments in private data centers.
    
 ---
    
 <p><a href="https://oracle-samples.github.io/oltrain/OSMS/osms.html"><img id="osms" src="common/images/osms-banner3.png"></a></p>   
    
-- [OS Management Service](./OSMS/osms.md) - Learn how to use the OS Management service to manage updates and patches for your operating system environments on your Oracle Cloud Infrastructure instances.
+- [Oracle OS Management Service](./OSMS/osms.md) - Learn how to use the Oracle OS Management service to manage updates and patches for your operating system environments on your Oracle Cloud Infrastructure instances.
    
 ---
    

--- a/Whats_New/new.md
+++ b/Whats_New/new.md
@@ -11,8 +11,8 @@ This page highlights the videos and hands on labs that have been added to the le
 ### New Videos
 
 - [Oracle OS Management Hub: Overview](https://youtu.be/zBDX5VmurZM)
-- [Preparing Oracle Cloud Infrastructure for OS Management Hub](https://youtu.be/LMxfUj93ozc)
-- [Creating and Registering a Management Station in OS Management Hub](https://youtu.be/cYN_ZWkLzCc)
+- [Preparing Oracle Cloud Infrastructure for Oracle OS Management Hub](https://youtu.be/LMxfUj93ozc)
+- [Creating and Registering a Management Station in Oracle OS Management Hub](https://youtu.be/cYN_ZWkLzCc)
 
 ---
 
@@ -43,7 +43,7 @@ This page highlights the videos and hands on labs that have been added to the le
 
 ### New Videos
 
-- [Working with Software Sources in OS Management](https://youtu.be/zPnfHO8cu-E)
+- [Working with Software Sources in Oracle OS Management](https://youtu.be/zPnfHO8cu-E)
 
 ---
 


### PR DESCRIPTION
updating text references from 'OS Management service/hub' to 'Oracle OS Management Hub/Service' on the home page(read.me) and the What's new page.