### PR TITLE
Add new Install kind on rootless podman lab

### DIFF
--- a/content/ol/virt/virt.md
+++ b/content/ol/virt/virt.md
@@ -208,13 +208,21 @@ It can be deployed on either a Kubernetes cluster using an Operator, or as a sta
 
 Learn to setup and use a HAProxy container on Podman.
 
-HAProxy is a well known, and widely used, open source solution delivering load balancing and proxy services for both HTTP (Layer 7) and TCP (Layer 4) which is achieved by spreading incoming request across multiple servers. For more details of the services that HAProxy does and does not provide please refer to the [upstream documentation] (https://docs.haproxy.org/#xd_co_f=NjUzNDIzODAtMTcwNy00YzFlLTgxMDItNTM2YjIwZjBkMmQ0~). HAProxy can be installed locally on Oracle Linux , or run as a container using Podman. This lab describes how to use HAProxy with Podman.
+HAProxy is a well known, and widely used, open source solution delivering load balancing and proxy services for both HTTP (Layer 7) and TCP (Layer 4) which is achieved by spreading incoming request across multiple servers. For more details of the services that HAProxy does and does not provide please refer to the [upstream documentation](https://docs.haproxy.org/). HAProxy can be installed locally on Oracle Linux , or run as a container using Podman. This lab describes how to use HAProxy with Podman.
 
 ---
 
 ### [Deploy a High Availability Project Quay using Podman](https://luna.oracle.com/lab/a63c2548-c459-457f-b3d1-123c99d90d89)
 
 Learn to setup and use a high availability deployment of Project Quay Registry on Podman.
+
+---
+
+### [Install kind Using Rootless Podman on Oracle Linux](https://luna.oracle.com/lab/30610e81-95e7-4c54-85bc-efcb5e757e04)
+
+Learn how to install _kind_ using rootless Podman on Oracle Linux.
+
+[kind](https://kind.sigs.k8s.io/) is an open source tool for running a locally hosted Kubernetes cluster using Podman containers as the cluster nodes.  It is specifically designed to provide both Developers and DevOps administrators to quickly create a Kubernetes cluster on a single machine without requiring the complicated and lengthy process of bootstrapping and then configuring the cluster, etc.  Instead kind maintains all the components for both control plane and worker nodes.
 
 ---
 

--- a/content/whats-new/new.md
+++ b/content/whats-new/new.md
@@ -27,7 +27,7 @@ aliases:
 
 ---
 
-This page highlights the videos and hands on labs that have been added to the learning tracks on the Oracle Linux Training Station in the period November 2022 - July 2023.
+This page highlights the videos and hands on labs that have been added to the learning tracks on the Oracle Linux Training Station in the period November 2022 - August 2023.
 
 ---
 
@@ -69,6 +69,7 @@ This page highlights the videos and hands on labs that have been added to the le
 - [Use ReaR to Perform an Oracle Linux Backup](https://luna.oracle.com/lab/30023183-ca96-48dc-8497-af04ca1eada4)
 - [Install Oracle Java SE on Oracle Linux](https://luna.oracle.com/lab/00f34840-f6d0-47dc-9a83-0cc6abd5d051)
 - [Run Oracle Database on Oracle Linux for Arm](https://luna.oracle.com/lab/2a32f4bb-2cd1-4f9f-a900-db8f147c0b14)
+- [Install kind Using Rootless Podman on Oracle Linux](https://luna.oracle.com/lab/30610e81-95e7-4c54-85bc-efcb5e757e04)
 
 ---
 


### PR DESCRIPTION
Things altered in this PR:

- Added new 'Install kind Using Rootless Podman on Oracle Linux' Lab to the OL track
- Added above Lab to the 'What's New' page
- Corrected formatting issue with hyperlink for the 'Deploy HAProxy using Podman' Lab on the OL track
- Updated the 'What's New' page to extend the period covered from: 'November 2022 - July 2023' to now be: 'November 2022 - August 2023'  