### PR TITLE
Correct Playlist menu option name

### DIFF
--- a/config/_default/menus.en.toml
+++ b/config/_default/menus.en.toml
@@ -197,7 +197,7 @@
   weight = 210
 
 [[main]]
-  name = "Oracle Cloud Infrastructure"
+  name = "Linux on Oracle Cloud Infrastructure"
   identifier = "pl3"
   parent = "pl"
   url = "https://www.youtube.com/playlist?list=PLKCk3OyNwIzu51n3L6dxHgKRy8CayIBXI"


### PR DESCRIPTION
Correct the playlist name for one of the YouTube tracks which was originally listed as "Oracle Cloud Infrastructure" to use it's full/correct name of "Linux on Oracle Cloud Infrastructure"