### PR TITLE
Correct typo in a couple of systemd videos

### DIFF
--- a/content/ol/inst_boot/inst_boot.md
+++ b/content/ol/inst_boot/inst_boot.md
@@ -52,11 +52,11 @@ aliases:
 
 - {{< youtube OVeso8h5HZA >}}
 
-### sytemd System and Service Manager on Oracle Linux
+### systemd System and Service Manager on Oracle Linux
 
 - {{< youtube 9uDvnZKhU8A >}}
 
-### sytemd Target Units on Oracle Linux
+### systemd Target Units on Oracle Linux
 
 - {{< youtube Tkxs-wfZrnw >}}
 


### PR DESCRIPTION
Correct a typo in these videos in the Oracle Linux, Installation and Boot Process section :

- systemd System and Service Manager on Oracle Linux
- systemd Target Units on Oracle Linux