### PR TITLE
Fix typo in OLOCI video title

### DIFF
--- a/content/oloci/oloci.md
+++ b/content/oloci/oloci.md
@@ -270,7 +270,7 @@ Learn to implement KVM virtualization in Oracle Linux instances deployed on Orac
 
 ### Videos
 
-#### Use Oracle Linux KVM Image for Oracle cloud Infrastructure
+#### Use Oracle Linux KVM Image for Oracle Cloud Infrastructure
 
 - {{< youtube id="R-zJgRIfil4" title="Use Oracle Linux KVM Image for Oracle cloud Infrastructure YouTube video" >}}
 


### PR DESCRIPTION
Correct a typo in this video on the OLOCI section of OLTRAIN:

- Use Oracle Linux KVM Image for Oracle Cloud Infrastructure