### PR TITLE
Remove old content from the Whats New section

### DIFF
--- a/content/whats-new/new.md
+++ b/content/whats-new/new.md
@@ -27,7 +27,7 @@ aliases:
 
 ---
 
-This page highlights the videos and hands on labs that have been added to the learning tracks on the Oracle Linux Training Station in the period November 2022 - August 2023.
+This page highlights the videos and hands on labs that have been recently added to the learning tracks on the Oracle Linux Training Station.
 
 ---
 
@@ -52,18 +52,10 @@ This page highlights the videos and hands on labs that have been added to the le
 ### New Videos
 
 - [Use Gprofng for Performance Profiling Applications](https://youtu.be/TRZNoL_7xro)
-- [Install Oracle Linux 9](https://youtu.be/BDmBtP4Y7Wg)
 - [Ksplice Known Exploit Detection](https://youtu.be/13R21lfYy74)
 
 ### New Labs
 
-- [Switch from CentOS 7 to Oracle Linux 7](https://luna.oracle.com/lab/660a07d9-0580-4fae-973b-d5dfaebda1cb)
-- [Install Podman Desktop](https://luna.oracle.com/lab/55225d03-4fdb-42dd-bb3c-0382cb918963)
-- [Using Compose Files with Podman](https://luna.oracle.com/lab/0e800b97-2c1b-43a8-b0f0-003f1543d2ba)
-- [Learn to Install Project Quay on Podman](https://luna.oracle.com/lab/e3f488a9-20a8-49d8-ae08-818f8730568c)
-- [Deploy HAProxy using Podman](https://luna.oracle.com/lab/a9eb9ff9-b56d-4ddc-9283-b72467d78128)
-- [Introduction to Oracle Linux: Shell and Command Line](https://luna.oracle.com/lab/facec73e-8517-4314-877f-d4f8f429c5ab)
-- [Deploy a High Availability Project Quay on Podman](https://luna.oracle.com/lab/a63c2548-c459-457f-b3d1-123c99d90d89)
 - [Get Started with Oracle Database Free on Oracle Linux](https://luna.oracle.com/lab/8dd46cea-3e27-4774-bb12-fc97a4babe06)
 - [Disable a Kernel Module on Oracle Linux](https://luna.oracle.com/lab/00aafe17-39b9-43e0-8b53-087b84003c15)
 - [Use ReaR to Perform an Oracle Linux Backup](https://luna.oracle.com/lab/30023183-ca96-48dc-8497-af04ca1eada4)
@@ -73,25 +65,13 @@ This page highlights the videos and hands on labs that have been added to the le
 
 ---
 
-{{< figure src="/img/osms/osms-banner-v2.png" alt="OSM banner" >}}
-
-## Oracle OS Management on Oracle Cloud Infrastructure
-
-### New Videos
-
-- [Working with Software Sources in Oracle OS Management](https://youtu.be/zPnfHO8cu-E)
-
----
-
 {{< figure src="/img/ocne/OCNE-banner-v2.png" alt="OCNE banner" >}}
 
 ## Oracle Cloud Native Environment
 
 ### New Labs
 
-- [Use Quick Install to Deploy Oracle Cloud Native Environment](https://luna.oracle.com/lab/42f9b19b-e254-42cf-885d-a80127d9d751)
 - [Provision PersistentVolumes Using File Storage Service on Oracle Cloud Native Environment](https://luna.oracle.com/lab/5d95fdca-c690-4ebf-8ac0-315ac095ac59)
-- [Upgrade to Oracle Cloud Native Environment 1.6](https://luna.oracle.com/lab/fa8fc61b-893c-4507-93a2-711540e9ace7)
 - [Introducing Kubectl with Oracle Cloud Native Environment](https://luna.oracle.com/lab/6c65a513-b161-47d2-b45c-92ca02e38dc0)
 - [Use Kubectl to Manage Kubernetes Clusters and Nodes](https://luna.oracle.com/lab/4b16d141-4825-4d54-98f3-ce7babbea45c)
 
@@ -105,9 +85,6 @@ This page highlights the videos and hands on labs that have been added to the le
 
 - [Oracle Compute Cloud@Customer Service Overview](https://youtu.be/ZzmsCP-dAZE)
 - [Oracle Cloud Infrastructure Secure Desktops: Overview](https://youtu.be/pwElvYIZzaM)
-- [Connect Virtual Cloud Networks to On-Premises Networks using the Site-to-Site VPN Wizard](https://youtu.be/0_WpIxFyyck)
-- [Use the VCN Wizard to create a Virtual Cloud Network in the Oracle Cloud Infrastructure](https://youtu.be/-6B5_5Qih98)
-- [OCI Utilities Overview](https://youtu.be/bnf9T-wljVU)
 
 ---
 
@@ -115,48 +92,10 @@ This page highlights the videos and hands on labs that have been added to the le
 
 ## Oracle Linux Automation Manager
 
-### New Video
-
-- [Release Features of Oracle Linux Automation Manager 2.0](https://youtu.be/2UwUXngKsDY)
-
 ### New Labs
 
-- [Upgrade to Oracle Linux Automation Manager](https://luna.oracle.com/lab/6c7124cc-474f-4dd4-89fa-9beb536c71f5)
-- [Migrate Oracle Linux Automation Manager to a Clustered Deployment](https://luna.oracle.com/lab/d1847f91-0cdc-41b8-afc4-eb6d0ccd40c2)
-- [Get Started with Oracle Linux Automation Manager](https://luna.oracle.com/lab/4a1dcd6e-231c-4724-ae52-8d56431a2888)
 - [Integrate LDAP User Management with Oracle Linux Automation Manager](https://luna.oracle.com/lab/a03cfc90-4c3c-488d-9e66-ba514e00b619)
-- [Use OCI Ansible Collection with Oracle Linux Automation Manager](https://luna.oracle.com/lab/b69c86cf-962a-40a9-8f3c-7a9018f4dc4b)
-- [Use Hop Nodes on Oracle Linux Automation Manager](https://luna.oracle.com/lab/c4780f15-bd17-468d-9133-3eba9bc0ff2a)
 - [Manage KVM Virtual Machines using Oracle Linux Automation Manager](https://luna.oracle.com/lab/3e869b97-6f71-46fa-a979-e0c8bf81d7d2)
 - [Setup HAProxy to Load Balance an Oracle Linux Automation Manager Cluster](https://luna.oracle.com/lab/1d19c310-b6d6-40a9-aa2b-44dee29a8f31)
 
----
 
-{{< figure src="/img/vbox/vbox-banner.png" alt="VirtualBox banner" >}}
-
-## Oracle VM VirtualBox
-
-### New Videos
-
-- [Use Oracle VM VirtualBox on Oracle Cloud Infrastructure Instances](https://youtu.be/QJ_z20kSxX4)
-- [Integrate VirtualBox 7.0 with Oracle Cloud Infrastructure](https://youtu.be/3roYMw-D2ks)
-
-### New Labs
-
-- [Use Oracle VM VirtualBox on Oracle Cloud Infrastructure Instances](https://luna.oracle.com/lab/922eabed-e47c-4934-a4a5-dbacc02f4f3b)
-
----
-
-{{< figure src="/img/opca/PCA-banner-v2.png" alt="OPCA banner" >}}
-
-## Oracle Private Cloud Appliance
-
-### New Videos
-
-- [Mounting File Systems on Oracle Private Cloud Appliance](https://youtu.be/RZoIqkCPSBQ)
-- [Managing Object Storage Buckets on Oracle Private Cloud Appliance](https://youtu.be/t6e_T0qJrNg)
-- [Creating a File System on Oracle Private Cloud Appliance](https://youtu.be/lB03H7YJP0Q)
-- [Importing Compute Images Provided with Oracle Private Cloud Appliance](https://youtu.be/fToYmmf6NFk)
-- [Managing Mount Targets on Oracle Private Cloud Appliance](https://youtu.be/bTmckStW_wY)
-- [Local Peering Gateways on Oracle Private Cloud Appliance](https://youtu.be/pxdkxjajhO0)
-- [Managing Object Versioning on Oracle Private Cloud Appliance](https://youtu.be/wS6jhUwK6Fk)


### PR DESCRIPTION
Removed the following from the 'What's New' section:

- Install Oracle Linux 9

- nstall Podman Desktop
- Using Compose Files with Podman
- Learn to Install Project Quay on Podman
- Deploy HAProxy using Podman
- Introduction to Oracle Linux: Shell and Command Line
- Deploy a High Availability Project Quay on Podman


- Working with Software Sources in Oracle OS Management

- Use Quick Install to Deploy Oracle Cloud Native Environment


- Connect Virtual Cloud Networks to On-Premises Networks using the Site-to-Site VPN Wizard
- Use the VCN Wizard to create a Virtual Cloud Network in the Oracle Cloud Infrastructure
- OCI Utilities Overview


- Release Features of Oracle Linux Automation Manager 2.0


- Upgrade to Oracle Linux Automation Manager
- Migrate Oracle Linux Automation Manager to a Clustered Deployment
- Get Started with Oracle Linux Automation Manager
- Use OCI Ansible Collection with Oracle Linux Automation Manager
- Use Hop Nodes on Oracle Linux Automation Manager

- Use Oracle VM VirtualBox on Oracle Cloud Infrastructure Instances
- Integrate VirtualBox 7.0 with Oracle Cloud Infrastructure
- Use Oracle VM VirtualBox on Oracle Cloud Infrastructure Instances

- Mounting File Systems on Oracle Private Cloud Appliance
- Managing Object Storage Buckets on Oracle Private Cloud Appliance
- Creating a File System on Oracle Private Cloud Appliance
- Importing Compute Images Provided with Oracle Private Cloud Appliance
- Managing Mount Targets on Oracle Private Cloud Appliance
- Local Peering Gateways on Oracle Private Cloud Appliance
- Managing Object Versioning on Oracle Private Cloud Appliance





