### PR TITLE
Add new Oracle Linux Lab and update the "What's New" page

### DIFF
--- a/content/ol/admin/admin.md
+++ b/content/ol/admin/admin.md
@@ -255,6 +255,14 @@ The Oracle Cloud Infrastructure (OCI) Ampere A1 compute platform provides determ
 
 ---
 
+### [Get Started with Git on Oracle Linux](https://luna.oracle.com/lab/6c55a20f-e751-4326-a157-b16770262346)
+
+Git is a free and open-source Distributed Version Control System (DVCS) which is available for MacOS, MS Windows and Linux/Unix platforms. This lab only covers using Git on Oracle Linux, but the steps covered in this lab work for any platform.
+
+How does Git work? Git does not need a centrally located Git server to be fully functional. Instead, a simple project consists of a local folder on your computer containing files. Git then tracks any changes made to the directories and files contained within the project over time. It achieves this by storing the history and details of branches and commits locally without requiring a network connection.
+
+---
+
 {{< figure src="/img/quiz1.png" alt="ol-admin-quiz" >}}
 
 Test your skills on what you have learned so far with this quiz.

--- a/content/osd/osd.md
+++ b/content/osd/osd.md
@@ -53,6 +53,6 @@ The Secure Desktops service provides:
 
 - {{< youtube id="ZbaQQ5M81Vs" title="Oracle Cloud Infrastructure Secure Desktops - User's Client View" >}}
 
-### Oracle Cloud Infrastructure Secure Desktops - Administration Workflow
+#### Oracle Cloud Infrastructure Secure Desktops - Administration Workflow
 
 - {{< youtube id="2VPp_0or1RU" title="Oracle Cloud Infrastructure Secure Desktops - Administration Workflow" >}}

--- a/content/whats-new/new.md
+++ b/content/whats-new/new.md
@@ -54,20 +54,17 @@ This page highlights the videos and hands on labs that have been recently added 
 
 ### New Videos
 
-- [Use Gprofng for Performance Profiling Applications](https://youtu.be/TRZNoL_7xro)
-- [Ksplice Known Exploit Detection](https://youtu.be/13R21lfYy74)
 - [Search Container Registries with Podman on Oracle Linux](https://youtu.be/p2FxmHbPFqM)
 
 ### New Labs
 
-- [Get Started with Oracle Database Free on Oracle Linux](https://luna.oracle.com/lab/8dd46cea-3e27-4774-bb12-fc97a4babe06)
-- [Disable a Kernel Module on Oracle Linux](https://luna.oracle.com/lab/00aafe17-39b9-43e0-8b53-087b84003c15)
 - [Use ReaR to Perform an Oracle Linux Backup](https://luna.oracle.com/lab/30023183-ca96-48dc-8497-af04ca1eada4)
 - [Install Oracle Java SE on Oracle Linux](https://luna.oracle.com/lab/00f34840-f6d0-47dc-9a83-0cc6abd5d051)
 - [Run Oracle Database on Oracle Linux for Arm](https://luna.oracle.com/lab/2a32f4bb-2cd1-4f9f-a900-db8f147c0b14)
 - [Install kind Using Rootless Podman on Oracle Linux](https://luna.oracle.com/lab/30610e81-95e7-4c54-85bc-efcb5e757e04)
 - [Use DNF to Maintain Security on Oracle Linux](https://luna.oracle.com/lab/b48151dc-20d9-4c52-b868-840978f4a514)
 - [Run Containers with Podman on Oracle Linux](https://luna.oracle.com/lab/2f0beeef-bc10-4e54-a042-ce31db0e9765)
+- [Get Started with Git on Oracle Linux](https://luna.oracle.com/lab/6c55a20f-e751-4326-a157-b16770262346)
 
 ---
 
@@ -77,9 +74,6 @@ This page highlights the videos and hands on labs that have been recently added 
 
 ### New Labs
 
-- [Provision PersistentVolumes Using File Storage Service on Oracle Cloud Native Environment](https://luna.oracle.com/lab/5d95fdca-c690-4ebf-8ac0-315ac095ac59)
-- [Introducing Kubectl with Oracle Cloud Native Environment](https://luna.oracle.com/lab/6c65a513-b161-47d2-b45c-92ca02e38dc0)
-- [Use Kubectl to Manage Kubernetes Clusters and Nodes](https://luna.oracle.com/lab/4b16d141-4825-4d54-98f3-ce7babbea45c)
 - [Run KubeVirt on Oracle Cloud Native Environment](https://luna.oracle.com/lab/87d85c56-d929-45bc-aa8c-3f51cd584b2d)
 - [Use ConfigMaps and Secrets with Oracle Cloud Native Environment](https://luna.oracle.com/lab/14984256-1691-4d7a-8468-6ff38b6253ad)
 
@@ -114,7 +108,4 @@ This page highlights the videos and hands on labs that have been recently added 
 
 ### New Labs
 
-- [Integrate LDAP User Management with Oracle Linux Automation Manager](https://luna.oracle.com/lab/a03cfc90-4c3c-488d-9e66-ba514e00b619)
-- [Manage KVM Virtual Machines using Oracle Linux Automation Manager](https://luna.oracle.com/lab/3e869b97-6f71-46fa-a979-e0c8bf81d7d2)
-- [Setup HAProxy to Load Balance an Oracle Linux Automation Manager Cluster](https://luna.oracle.com/lab/1d19c310-b6d6-40a9-aa2b-44dee29a8f31)
 - [Build Custom Execution Environments with Oracle Linux Automation Manager Builder Utility](https://luna.oracle.com/lab/b54dddd3-661b-43af-afae-192e5fbdab07)


### PR DESCRIPTION
Add a new Luna Lab to the _Oracle Linux_ Track:

 - "_Get Started with Git on Oracle Linux_"

Also remove old content from the "_What's New_" page (see below):

 - Oracle Linux (videos) section:
   - Use Gprofng for Performance Profiling Applications
   - Ksplice Known Exploit Detection
 
 - Oracle Linux (Labs) section:
   -  Get Started with Oracle Database Free on Oracle Linux
   - Disable a Kernel Module on Oracle Linux

 - Oracle Cloud Native Environment (Labs) section:
   - Provision PersistentVolumes Using File Storage Service on Oracle Cloud Native Environment
   - Introducing Kubectl with Oracle Cloud Native Environment
   - Use Kubectl to Manage Kubernetes Clusters and Nodes

 - Oracle Linux Automation Manager (Labs) section:
   - Integrate LDAP User Management with Oracle Linux Automation Manager
   - Manage KVM Virtual Machines using Oracle Linux Automation Manager
   - Setup HAProxy to Load Balance an Oracle Linux Automation Manager Cluster

